### PR TITLE
fix findSchemaNames() for non-dba user

### DIFF
--- a/db/oci/Schema.php
+++ b/db/oci/Schema.php
@@ -309,12 +309,12 @@ SQL;
     {
         $sql = <<<SQL
 SELECT username
-  FROM dba_users u
+  FROM all_users u
  WHERE EXISTS (
     SELECT 1
-      FROM dba_objects o
+      FROM all_objects o
      WHERE o.owner = u.username )
-   AND default_tablespace not in ('SYSTEM','SYSAUX')
+--   AND default_tablespace not in ('SYSTEM','SYSAUX')
 SQL;
         return $this->db->createCommand($sql)->queryColumn();
     }


### PR DESCRIPTION
While using non-DBA user in Oracle database, we can't use "dba_users" and "dba_objects" tables.
So we need to use "all_users" and "all_objects" instead.