### PR TITLE
Fix string(0) POST param default value

### DIFF
--- a/web/Request.php
+++ b/web/Request.php
@@ -447,7 +447,7 @@ class Request extends \yii\base\Request
     {
         $params = $this->getBodyParams();
 
-        return (isset($params[$name]) && $params[$name]) ? $params[$name] : $defaultValue;
+        return (isset($params[$name]) && $params[$name] !== '') ? $params[$name] : $defaultValue;
     }
 
     /**

--- a/web/Request.php
+++ b/web/Request.php
@@ -447,7 +447,7 @@ class Request extends \yii\base\Request
     {
         $params = $this->getBodyParams();
 
-        return isset($params[$name]) ? $params[$name] : $defaultValue;
+        return (isset($params[$name]) && $params[$name]) ? $params[$name] : $defaultValue;
     }
 
     /**


### PR DESCRIPTION
Hi all, i have strange situation on Yii2-advanced vagrant (the beginning of June) with PHP Version 5.5.9-1ubuntu4.21

input `echo Html::input('hidden','crop_w', null, ['id'=>'crop_w']);` 
and
$_POST data
```
Array
(
    [_csrf-backend] => hiXlj7zoZ09rWYdnpJfwbOCkmjxf7V3uTp098P-rQonTFqbl2tgIIA494B31_sElpcXTWzaAN5sH7Wqlu_4B3Q==
    [Articles] => Array
        (
            [title] => news qwer54
            [publish_date] => 2017-07-18 09:15:11
            [end_publish_date] => 
            [status] => 1
            [areasrelations] => Array
                (
                    [0] => 6
                )

            [image] => 
            [post] => 
text



            [tagsrelations] => 
            [category_id] => 5
            [added_date] => 2017-07-14 13:37:02
            [important] => 0
            [annotation] => 
        )

    [crop_x] => 
    [crop_y] => 
    [crop_w] => 
    [crop_h] => 
)
```

if i\`m using ```$request->post('crop_w', 500)```
`var_dump($params[$name]) from Request.php->getBodyParam  = string(0)`  and `$defaultValue` didn`t return.