### PR TITLE
Fixes #15117 `yii\db\Schema::getTableMetadata` cache refreshing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 Change Log
 - Bug #16010: Fixed `yii\filters\ContentNegotiator` behavior when GET parameters contain an array (rugabarbo)
 - Bug #14660: Fixed `yii\caching\DbCache` concurrency issue when set values with the same key (rugabarbo)
 - Bug #15988: Fixed bash completion (alekciy)
+- Bug #15117: Fixed `yii\db\Schema::getTableMetadata` cache refreshing (boboldehampsink)
 
 2.0.15.1 March 21, 2018
 -----------------------

--- a/db/Schema.php
+++ b/db/Schema.php
@@ -737,10 +737,10 @@ abstract class Schema extends BaseObject
             }
         }
         $rawName = $this->getRawTableName($name);
-        if ($refresh || !isset($this->_tableMetadata[$rawName])) {
+        if (!isset($this->_tableMetadata[$rawName])) {
             $this->loadTableMetadataFromCache($cache, $rawName);
         }
-        if (!array_key_exists($type, $this->_tableMetadata[$rawName])) {
+        if ($refresh || !array_key_exists($type, $this->_tableMetadata[$rawName])) {
             $this->_tableMetadata[$rawName][$type] = $this->{'loadTable' . ucfirst($type)}($rawName);
             $this->saveTableMetadataToCache($cache, $rawName);
         }


### PR DESCRIPTION
Fixes #15117. Before, setting `$refresh` still tried to pull from the cache. With this fix it doesn't and makes sure it loads from table again.