### PR TITLE
Update ActiveRelationTrait.php

### DIFF
--- a/db/ActiveRelationTrait.php
+++ b/db/ActiveRelationTrait.php
@@ -523,7 +523,8 @@ trait ActiveRelationTrait
             // single key
             $attribute = reset($this->link);
             foreach ($models as $model) {
-                if (($value = $model[$attribute]) !== null) {
+                if ($model !== null) {
+                    $value = $model[$attribute];
                     if (is_array($value)) {
                         $values = array_merge($values, $value);
                     } elseif ($value instanceof ArrayExpression && $value->getDimension() === 1) {


### PR DESCRIPTION
Fix for PHP 7.4

Trying to access array offset on value of type null
When:
if (($value = $model[$attribute]) !== null) 

/var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveRelationTrait.php line 526

#0 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveRelationTrait.php(526): yii\base\ErrorHandler->handleError()
#1 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveRelationTrait.php(246): yii\db\ActiveQuery->filterByModels()
#2 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveQueryTrait.php(151): yii\db\ActiveQuery->populateRelation()
#3 /var/www/builds/cms/3.6.0/vendor/yiisoft/yii2/db/ActiveQuery.php(224): yii\db\ActiveQuery->findWith()

<!--
Please use https://github.com/yiisoft/yii2 to report issues and send pull requests. Thank you!
-->
